### PR TITLE
fix sock5 startup fails

### DIFF
--- a/src/ubuntu/install/corplink/install_corplink.sh
+++ b/src/ubuntu/install/corplink/install_corplink.sh
@@ -33,6 +33,7 @@ mkdir -p /var/log/socks5/
 cat <<EOF >/etc/supervisor/conf.d/socks5.conf
 [program:socks5]
 command=/usr/local/bin/socks5
+environment=REQUIRE_AUTH=false
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/socks5/stderr.log


### PR DESCRIPTION
Error: REQUIRE_AUTH is true, but PROXY_USER and PROXY_PASSWORD are not set.  The application will now exit.